### PR TITLE
Use Rocker before Jekyll

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,47 +1,69 @@
 # Explicitly set Jekyll version across all repos
 ARG JEKYLL_VERSION=3.8.5
-FROM jekyll/jekyll:${JEKYLL_VERSION}
-COPY ./Gemfile /srv/gems/Gemfile
+FROM rocker/verse:latest
 
-WORKDIR /srv
-
-RUN chown jekyll:jekyll gems \
-  && cd gems \
-  && bundle update \
-  && bundle install
-
-# This is apparently how you jackknife one container into another and it's 
-# WEIRD ಠ_ಠ
-# https://github.com/moby/moby/issues/3378#issuecomment-411824851
-COPY --from=rocker/verse:latest / /
-
-# N.B. This is not working at the moment because jekyll is giving me this error
-# when I try to run jekyll as the jekyll user:
+# Set up jekyll
 #
-# $ /usr/jekyll/bin/jekyll --help
-# /usr/jekyll/bin/jekyll: 5: /usr/jekyll/bin/jekyll: default-args: not found
-#
-# It's a bit weird because the scripts definitely exist there
-# https://github.com/envygeeks/jekyll-docker/blob/master/repos/jekyll/copy/all/usr/jekyll/bin/entrypoint
-# This will effectively make the current UID to be jekyll so that whenever R or
-# jekyll runs something, it will be written as the current user ID instead of
-# root or jekyll.
-ENV JEKYLL_UID=0
-ENV JEKYLL_GID=0
+# Most of these are lifted directly from <https://github.com/envygeeks/jekyll-docker>
+
+# --
+# EnvVars
+# Ruby
+# --
+
 ENV BUNDLE_HOME=/usr/local/bundle
 ENV BUNDLE_APP_CONFIG=/usr/local/bundle
 ENV BUNDLE_BIN=/usr/local/bundle/bin
 ENV GEM_BIN=/usr/gem/bin
 ENV GEM_HOME=/usr/gem
+
+# --
+# EnvVars
+# Image
+# --
 ENV JEKYLL_VAR_DIR=/var/jekyll
-ENV JEKYLL_DATA_DIR=/srv/jekyll
+ENV JEKYLL_VERSION=3.8.5
+ENV JEKYLL_DATA_DIR=/srv/site
 ENV JEKYLL_BIN=/usr/jekyll/bin
 ENV JEKYLL_ENV=development
 
-RUN R -e "devtools::install_github('hadley/requirements')"
-RUN mkdir /srv/site
-COPY ./bin/docker-setup.sh /srv/site/bin/docker-setup.sh
+# --
+# EnvVars
+# System
+# --
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV PATH="${JEKYLL_BIN}:${BUNDLE_BIN}:$PATH"
+
+WORKDIR /srv/gems
+COPY ./Gemfile /srv/gems/Gemfile
+
+# Install Jekyll and build the Gems
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  ruby-full \
+  build-essential \
+  zlib1g-dev \
+  && mkdir -p $JEKYLL_VAR_DIR \
+  && mkdir -p $JEKYLL_DATA_DIR \
+  && echo "gem: --no-ri --no-rdoc" > ~/.gemrc \
+  && unset GEM_HOME \
+  && unset GEM_BIN \
+  && yes | gem update --system \
+  && unset GEM_HOME \
+  && unset GEM_BIN \
+  && yes | gem install --force bundler \
+  && gem install jekyll -v${JEKYLL_VERSION} -- --use-system-libraries \
+  && bundle update \
+  && bundle install 
 
 WORKDIR /srv/site
+COPY ./bin/docker-setup.sh /srv/site/bin/docker-setup.sh
+
+RUN R -e "devtools::install_github('hadley/requirements')" 
+
 
 ENTRYPOINT /bin/bash -c bin/docker-setup.sh && bash
+
+EXPOSE 35729
+EXPOSE 4000
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,24 +13,34 @@ ENV PATH="${JEKYLL_BIN}:${BUNDLE_BIN}:$PATH"
 WORKDIR /srv/gems
 COPY ./Gemfile /srv/gems/Gemfile
 
+# Install ruby and python pip
 RUN apt-get update && apt-get install -y --no-install-recommends \
   apt-utils \
   ruby \
   ruby-dev \
   build-essential \
   libxml2-dev \
+  python3-pip \
+  python3-setuptools \
   && echo "gem: --no-ri --no-rdoc" > ~/.gemrc 
 
+# Install PyYAML for checking validity of episodes
+RUN pip3 install wheel \
+  && pip3 install PyYAML
+
+# Setup and install jekyll. 
 RUN export PATH=$(ruby -e 'puts Gem.user_dir')"/bin":$PATH \
   && yes | gem install --force bundler \
   && bundle install \
   && bundle update \
   && useradd jekyll 
 
-
+# Set the working directory and add the setup script
 WORKDIR /srv/site
 COPY ./bin/docker-setup.sh /usr/local/bin/docker-setup.sh
 
+# Install requirements package and allow users to install
+# R packages when building the lessons
 RUN R -e "devtools::install_github('hadley/requirements')" 
 RUN mkdir -p /home/jekyll/RLibrary \
  && echo "R_LIBS=~/RLibrary" > /home/jekyll/.Renviron \

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,16 +25,18 @@ RUN export PATH=$(ruby -e 'puts Gem.user_dir')"/bin":$PATH \
   && yes | gem install --force bundler \
   && bundle install \
   && bundle update \
-  && useradd --no-create-home jekyll \
-  && mkdir -p /home/jekyll/Rlibrary
+  && useradd jekyll 
 
 
 WORKDIR /srv/site
 COPY ./bin/docker-setup.sh /usr/local/bin/docker-setup.sh
 
 RUN R -e "devtools::install_github('hadley/requirements')" 
-RUN echo "R_LIBS=~/RLibrary" > ~/.Renviron \
+RUN mkdir -p /home/jekyll/RLibrary \
+ && echo "R_LIBS=~/RLibrary" > /home/jekyll/.Renviron \
  && chown -R jekyll:jekyll /home/jekyll
+
+ENV R_ENVIRON_USER=~/.Renviron
 
 ENTRYPOINT ["/usr/local/bin/docker-setup.sh"]
 CMD ["make", "serve-in-container"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN mkdir -p /home/jekyll/RLibrary \
 ENV R_ENVIRON_USER=~/.Renviron
 
 ENTRYPOINT ["/usr/local/bin/docker-setup.sh"]
-CMD ["make", "serve-in-container"]
+CMD ["bash"]
 
 EXPOSE 35729
 EXPOSE 4000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,69 +1,43 @@
-# Explicitly set Jekyll version across all repos
-ARG JEKYLL_VERSION=3.8.5
 FROM rocker/verse:latest
-
-# Set up jekyll
-#
-# Most of these are lifted directly from <https://github.com/envygeeks/jekyll-docker>
 
 # --
 # EnvVars
 # Ruby
 # --
 
-ENV BUNDLE_HOME=/usr/local/bundle
-ENV BUNDLE_APP_CONFIG=/usr/local/bundle
 ENV BUNDLE_BIN=/usr/local/bundle/bin
-ENV GEM_BIN=/usr/gem/bin
-ENV GEM_HOME=/usr/gem
-
-# --
-# EnvVars
-# Image
-# --
-ENV JEKYLL_VAR_DIR=/var/jekyll
 ENV JEKYLL_VERSION=3.8.5
-ENV JEKYLL_DATA_DIR=/srv/site
 ENV JEKYLL_BIN=/usr/jekyll/bin
-ENV JEKYLL_ENV=development
-
-# --
-# EnvVars
-# System
-# --
-ENV LANG=en_US.UTF-8
-ENV LANGUAGE=en_US:en
 ENV PATH="${JEKYLL_BIN}:${BUNDLE_BIN}:$PATH"
 
 WORKDIR /srv/gems
 COPY ./Gemfile /srv/gems/Gemfile
 
-# Install Jekyll and build the Gems
 RUN apt-get update && apt-get install -y --no-install-recommends \
-  ruby-full \
+  apt-utils \
+  ruby \
+  ruby-dev \
   build-essential \
-  zlib1g-dev \
-  && mkdir -p $JEKYLL_VAR_DIR \
-  && mkdir -p $JEKYLL_DATA_DIR \
-  && echo "gem: --no-ri --no-rdoc" > ~/.gemrc \
-  && unset GEM_HOME \
-  && unset GEM_BIN \
-  && yes | gem update --system \
-  && unset GEM_HOME \
-  && unset GEM_BIN \
+  libxml2-dev \
+  && echo "gem: --no-ri --no-rdoc" > ~/.gemrc 
+
+RUN export PATH=$(ruby -e 'puts Gem.user_dir')"/bin":$PATH \
   && yes | gem install --force bundler \
-  && gem install jekyll -v${JEKYLL_VERSION} -- --use-system-libraries \
+  && bundle install \
   && bundle update \
-  && bundle install 
+  && useradd --no-create-home jekyll \
+  && mkdir -p /home/jekyll/Rlibrary
+
 
 WORKDIR /srv/site
-COPY ./bin/docker-setup.sh /srv/site/bin/docker-setup.sh
+COPY ./bin/docker-setup.sh /usr/local/bin/docker-setup.sh
 
 RUN R -e "devtools::install_github('hadley/requirements')" 
+RUN echo "R_LIBS=~/RLibrary" > ~/.Renviron \
+ && chown -R jekyll:jekyll /home/jekyll
 
-
-ENTRYPOINT /bin/bash -c bin/docker-setup.sh && bash
+ENTRYPOINT ["/usr/local/bin/docker-setup.sh"]
+CMD ["make", "serve-in-container"]
 
 EXPOSE 35729
 EXPOSE 4000
-

--- a/README.md
+++ b/README.md
@@ -3,7 +3,30 @@
 This creates a simple docker container that has Jekyll built on top of 
 [rocker/verse] with Hadley Wickham's [{requirements}] doing the work of
 scanning RMarkdown files for content. This is designed to work with current
-iterations 
+iterations of the lessons.
+
+To run this container, set your working directory to a lesson you maintain and
+run the following command:
+
+UNIX (MacOS and Linux):
+
+```sh
+docker run --rm -it -v $(pwd):/srv/site -p 4000:40000 -u $(id -u):$(id -g)
+zkamvar/carpentries-docker-test
+```
+
+Windows (n.b. this is untested)
+
+```sh
+docker run --rm -it -v=%cd%:/srv/site -p 4000:4000 zkamvar/carpentries-docker-test
+```
+
+Pros: no installation of jekyll, R, python, etc. required
+
+Cons: the container currently has no memory of the installed R packages and must
+rebuild these every time it is intialized. 
+
+
 
 
 [rocker/verse]: https://www.rocker-project.org/

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This creates a simple docker container that has Jekyll built on top of
 scanning RMarkdown files for content. This is designed to work with current
 iterations of the lessons.
 
+Ideally this should reduce the pain of running the lessons.
+
 To run this container, set your working directory to a lesson you maintain and
 run the following command:
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # carpentries-docker-test
 
-Testing docker for carpentries
+This creates a simple docker container that has Jekyll built on top of 
+[rocker/verse] with Hadley Wickham's [{requirements}] doing the work of
+scanning RMarkdown files for content. This is designed to work with current
+iterations 
+
+
+[rocker/verse]: https://www.rocker-project.org/
+[{requirements}]: https://github.com/hadley/requirements

--- a/bin/docker-setup.sh
+++ b/bin/docker-setup.sh
@@ -11,5 +11,19 @@ else
   chown jekyll:jekyll Gemfile
 fi
 
+echo "This is the alpha test of The Carpentries Lesson Template docker image."
+echo "Please let us know if you find any issues."
+echo ""
+echo "-----------------------------------------------------------------------------------"
+echo "To render your RMarkdown documents into markdown, please use the following command:"
+echo "    make lesson-md"
+echo ""
+echo "To preview your site, please use:"
+echo "    jekyll serve --host 0.0.0.0"
+echo "-----------------------------------------------------------------------------------"
+echo ""
+echo "You can edit your RMarkdown documents and re-render them using the commands"
+echo "above. When you are finished, you can type 'exit' to exit this container."
+echo ""
 
 exec "$@"

--- a/bin/docker-setup.sh
+++ b/bin/docker-setup.sh
@@ -1,16 +1,15 @@
 #!/bin/bash
 
-set -o errexit
-set -o pipefail
-set -o nounset
+set -e
 
-# Here, we are creating the user jekyll so that jekyll knows it's safe to play
-# with us. This *should* in theory have the same UID as
-useradd --no-create-home jekyll
-
-# This creates symbolic links from the src (which is where the lesson exists)
-# to where the site will be built to avoid permissions issues. 
-cp -rs /srv/src/* /srv/site/
 # This creates links to the gemfiles. The beauty behind this is that the
 # residual gemfiles are not present in the directory anymore. 
-cp -rs /srv/gems/* /srv/site/
+if [ -e Gemfile ]; then
+  echo "exists" > /dev/null
+else
+  cp /srv/gems/* /srv/site/
+  chown jekyll:jekyll Gemfile
+fi
+
+
+exec "$@"


### PR DESCRIPTION
This ditches the Jekyll docker container because it was too opinionated for our use case. Instead, we build off of rocker/verse and install jekyll and pip3. The Gemfiles are included so that the user does not have to worry about installing the gems up front. 

