### PR TITLE
lock R and Ruby versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/verse:latest
+FROM rocker/verse:3.6.3
 
 ENV BUNDLE_BIN=/usr/local/bundle/bin
 ENV JEKYLL_VERSION=3.8.5

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,49 @@
 FROM rocker/verse:3.6.3
 
 ENV BUNDLE_BIN=/usr/local/bundle/bin
-ENV JEKYLL_VERSION=3.8.5
 ENV JEKYLL_BIN=/usr/jekyll/bin
 ENV PATH="${JEKYLL_BIN}:${BUNDLE_BIN}:$PATH"
 
 WORKDIR /srv/gems
 COPY ./Gemfile /srv/gems/Gemfile
 
-# Install ruby and python pip
+# Install python pip for validity checks
 RUN apt-get update && apt-get install -y --no-install-recommends \
   apt-utils \
-  ruby \
-  ruby-dev \
   build-essential \
   libxml2-dev \
   python3-pip \
   python3-setuptools \
-  && echo "gem: --no-ri --no-rdoc" > ~/.gemrc 
+  jq \ 
+  gnupg2 \
+ && pip3 install wheel \
+ && pip3 install PyYAML
 
-# Install PyYAML for checking validity of episodes
-RUN pip3 install wheel \
-  && pip3 install PyYAML
+# Get requirements from GitHub
+RUN echo "gem: --no-ri --no-rdoc" > ~/.gemrc \
+ && wget -O ~/.ghvers.json "https://pages.github.com/versions.json" \
+ && RBY=$(cat ~/.ghvers.json | jq --raw-output '.ruby') \
+ && sed -i -e "s/RUBY_VERSION/${RBY}/" /srv/gems/Gemfile 
 
-# Setup and install jekyll. 
-RUN export PATH=$(ruby -e 'puts Gem.user_dir')"/bin":$PATH \
-  && yes | gem install --force bundler \
-  && bundle install \
-  && bundle update
+# Download the pinned Ruby version from GitHub
+RUN RBY=$(cat ~/.ghvers.json | jq --raw-output '.ruby') \
+ && RBY_MAJ=$(echo ${RBY} | sed -r -e "s/^([0-9]+[.][0-9]+)[.][0-9]+$/\1/") \
+ && wget -O ~/RUBY.tar.gz "https://cache.ruby-lang.org/pub/ruby/${RBY_MAJ}/ruby-${RBY}.tar.gz"
+
+# Install Ruby from source
+RUN cd ~ \
+ && RBY=$(cat ~/.ghvers.json | jq --raw-output '.ruby') \
+ && tar -xzvf RUBY.tar.gz\
+ && cd ruby-${RBY} \
+ && ./configure \
+ && make \
+ && sudo make install
+
+
+# Setup and install jekyll 
+RUN yes | gem install --force bundler \
+ && bundle install \
+ && bundle update
 
 # Set the working directory and add the setup script
 WORKDIR /srv/site

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,6 @@ source 'https://rubygems.org'
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 # Synchronize with https://pages.github.com/versions
-ruby '>=2.5.3'
+ruby 'RUBY_VERSION'
 
 gem 'github-pages', group: :jekyll_plugins

--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ docker run --rm -it \
   -v ${PWD}:/home/rstudio \
   -p 4000:4000 \
   -p 8787:8787 \
-  -e PASSWORD=yourpasswordhere \
   -e USERID=$(id -u) \
   -e GROUPID=$(id -g) \
   carpentries/lesson-docker
@@ -62,7 +61,6 @@ docker run --rm -it \
   -v ${PWD}:/home/rstudio \
   -p 4000:4000 \
   -p 8787:8787 \
-  -e PASSWORD=yourpasswordhere \
   carpentries/lesson-docker
 ```
 

--- a/bin/docker-setup.sh
+++ b/bin/docker-setup.sh
@@ -2,6 +2,7 @@
 
 set -e
 
+export PASSWORD=${PASSWORD:=data4Carp}
 # This creates links to the gemfiles. The beauty behind this is that the
 # residual gemfiles are not present in the directory anymore. 
 if [ -e Gemfile ]; then

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -1,5 +1,4 @@
-#!/usr/bin/execlineb -P
+#!/usr/bin/with-contenv bash
 
-exec /usr/local/bundle/bin/jekyll serve -s /home/rstudio -d /home/rstudio/_site --host 0.0.0.0 2>/dev/null
-
+exec ${BUNDLE_BIN}/jekyll serve -s /home/rstudio -d /home/rstudio/_site --host 0.0.0.0 
 


### PR DESCRIPTION
This locks the R and Ruby versions to close #4 

The solution to the ruby version was to install it from source instead of futzing around with environment managers that were strict on user permissions settings. 

This also changes the default so that a password is explicitly set if the user does not set it.