### PR TITLE
add auto-initialization; use renv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,14 +45,12 @@ RUN yes | gem install --force bundler \
  && bundle install \
  && bundle update
 
+# Install renv for checking dependencies
+RUN R -q -e "remotes::install_version('renv', '0.10.0', repos = 'https://cloud.r-project.org')"
+
 # Set the working directory and add the setup script
 WORKDIR /srv/site
 COPY ./bin/docker-setup.sh /usr/local/bin/docker-setup.sh
-
-# Install requirements package and allow users to install
-# R packages when building the lessons
-RUN R -q -e "devtools::install_github('hadley/requirements')" 
-RUN R -q -e "install.packages('renv')"
 
 # Start and finish scripts for jekyll server
 COPY bin/start.sh /etc/services.d/jekyll/run

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,8 @@ COPY ./bin/docker-setup.sh /usr/local/bin/docker-setup.sh
 
 # Install requirements package and allow users to install
 # R packages when building the lessons
-RUN R -e "devtools::install_github('hadley/requirements')" 
+RUN R -q -e "devtools::install_github('hadley/requirements')" 
+RUN R -q -e "install.packages('renv')"
 
 # Start and finish scripts for jekyll server
 COPY bin/start.sh /etc/services.d/jekyll/run

--- a/bin/docker-setup.sh
+++ b/bin/docker-setup.sh
@@ -5,6 +5,15 @@ set -e
 # set a default password
 export PASSWORD=${PASSWORD:=data4Carp}
 
+# Initialize lesson if it doesn't exist already
+if [ -e /home/rstudio/_config.yaml ]; then
+  echo "yaml exists" > /dev/null
+else
+  cd /home/rstudio
+  echo "Initializing lesson ..."
+  python3 bin/lesson_initialize.py
+fi
+
 # record the inital state of the directory so that we can remove the detritus later
 ls -1a /home/rstudio > /srv/in.txt
 
@@ -15,5 +24,6 @@ if [ -e /home/rstudio/Gemfile ]; then
 else
   cp -t /home/rstudio /srv/gems/Gemfile /srv/gems/Gemfile.lock
 fi
+
 
 exec "$@"

--- a/bin/docker-setup.sh
+++ b/bin/docker-setup.sh
@@ -4,26 +4,35 @@ set -e
 
 # set a default password
 export PASSWORD=${PASSWORD:=data4Carp}
+export USER=${USER:=rstudio}
 
 # Initialize lesson if it doesn't exist already
-if [ -e /home/rstudio/_config.yaml ]; then
+if [ -e /home/${USER}/_config.y*ml ]; then
   echo "yaml exists" > /dev/null
 else
-  cd /home/rstudio
+  cd /home/${USER}
   echo "Initializing lesson ..."
   python3 bin/lesson_initialize.py
 fi
 
 # record the inital state of the directory so that we can remove the detritus later
-ls -1a /home/rstudio > /srv/in.txt
+ls -1a /home/${USER} > /srv/in.txt
 
 # This creates links to the gemfiles. The beauty behind this is that the
 # residual gemfiles are not present in the directory anymore. 
-if [ -e /home/rstudio/Gemfile ]; then
+if [ -e /home/${USER}/Gemfile ]; then
   echo "exists" > /dev/null
 else
-  cp -t /home/rstudio /srv/gems/Gemfile /srv/gems/Gemfile.lock
+  cp -t /home/${USER} /srv/gems/Gemfile /srv/gems/Gemfile.lock
 fi
 
+# For the future: RStudio hosts binary packages for xenial and bionic, which 
+# makes installs MUCH faster. When they add buster, we can use this pattern to
+# take advantage of that service
+#
+# echo 'options(HTTPUserAgent = sprintf("R/%s R (%s)", getRversion(), paste(getRversion(), R.version$platform, R.version$arch, R.version$os)))' \
+#   >> /home/${USER}/.Rprofile
+# echo "options(repos = 'https://packagemanager.rstudio.com/all/__linux__/buster/latest')" \
+#   >> /home/${USER}/.Rprofile
 
 exec "$@"


### PR DESCRIPTION
This will auto-initialize the lesson if _config.yaml is missing. When
this wasn't present, jekyll would go in a loop trying to initialize
without success.

I've also added renv so that it can be used in the future (in case the
requirements package dies).
