### PR TITLE
Upgrade R to version 4.0.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/verse:3.6.3
+FROM rocker/verse:4.0.3
 
 ENV BUNDLE_BIN=/usr/local/bundle/bin
 ENV JEKYLL_BIN=/usr/jekyll/bin


### PR DESCRIPTION
Updating R to major version 4. Worked with the  swcarpentry/r-novice-gapminder lesson generation.

Closes carpentries/lesson-docker#11